### PR TITLE
Add compatibility for Laravel 11 and 12

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -17,7 +17,7 @@ jobs:
           php-version: "8.1"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-stable-laravel-10.x-php-8.1-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           extensions: curl, mbstring, pdo, sqlite, pdo_sqlite
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-stable-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,16 +9,25 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.2 ]
-        laravel: [ 9.*, 10.* ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        laravel: [ 9.*, 10.*, 11.*, 12.* ]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+        exclude:
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -35,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
+          composer update --prefer-stable --prefer-dist --no-interaction --no-progress --ansi --no-suggest
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,9 @@
         "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/contracts": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/http": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
         "ramsey/uuid": "^4.7"
     },
     "suggest": {


### PR DESCRIPTION
### Summary

This PR updates the `composer.json` file to add support for Laravel versions 11 and 12.

### Changes

- Extended version constraints for the following packages:
  - `illuminate/contracts`
  - `illuminate/http`
  - `illuminate/support`